### PR TITLE
Update TypeScript dependency version to 4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "gray-matter": "^4.0.2",
     "preact": "^10.5.12",
     "remark": "^13.0.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2555,10 +2555,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-typescript@*, typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@*, typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
- Resolves #54 
  - `noPropertyAccessFromIndexSignature` is added in TypeScript `4.2`.
  - So this PR updates the TypeScript dependency version of this repo to `4.2.3`.