### PR TITLE
[PT-BR] By Example.md and Do's and Dont's.md

### DIFF
--- a/docs/documentation/pt/declaration-files/By Example.md
+++ b/docs/documentation/pt/declaration-files/By Example.md
@@ -1,0 +1,250 @@
+---
+title: Declaration Reference
+layout: docs
+permalink: /pt/docs/handbook/declaration-files/by-example.html
+oneline: "Como criar um arquivo d.ts para um módulo"
+---
+
+O propósito desse guia é te ensinar como escrever um arquivo de definição de alta qualidade.
+A estrutura desse guia exibe a documentação de uma API, juntamente com amostras de uso e explicações de como escrever a declaração correspondente.
+
+Esses exemplos são ordenados por ordem crescente aproximada de complexidade.
+
+## Objetos com Propriedades
+
+_Documentação_
+
+> A variável global `minhaLib` possui uma função `criaCumprimento` para criar saudações,
+> e uma propriedade `numeroDeCumprimentos` indicando o numero de cumprimentos feitos ate ali.
+
+_Código_
+
+```ts
+let resultado = minhaLib.criaCumprimento("Olá, mundo");
+console.log("O cumprimento computado é:" + resultado);
+
+let count = minhaLib.numeroDeCumprimentos;
+```
+
+_Declaração_
+
+Use `declare namespace` para descrever tipos ou valores acessados via notação por ponto.
+
+```ts
+declare namespace minhaLib {
+  function criaCumprimento(s: string): string;
+  let numeroDeCumprimentos: number;
+}
+```
+
+## Funções Sobrecarregadas
+
+_Documentação_
+
+A função `pegaFerramenta` aceita um número e retorna uma Ferramenta, ou aceita uma string e retorna um array de Ferramentas.
+
+_Código_
+
+```ts
+let x: Ferramenta = pegaFerramenta(43);
+
+let arr: Ferramenta[] = pegaFerramenta("todas");
+```
+
+_Declaração_
+
+```ts
+declare function pegaFerramenta(n: number): Ferramenta;
+declare function pegaFerramenta(s: string): Ferramenta[];
+```
+
+## Tipos Reutilizáveis (Interfaces)
+
+_Documentação_
+
+> Ao especificar uma saudação, você deve passar um objeto `ConfiguracoesCumprimento`.
+> Esse objeto tem as seguintes propriedades: 
+>
+> 1 - cumprimento: String obrigatória
+>
+> 2 - duracao: Comprimento de tempo opcional (em milissegundos)
+>
+> 3 - cor: String opcional, ex: '#ff00ff'
+
+_Código_
+
+```ts
+cumprimenta({
+  cumprimento: "olá mundo",
+  duracao: 4000
+});
+```
+
+_Declaração_
+
+Use uma `interface` para definir um tipo com propriedades.
+
+```ts
+interface ConfiguracoesCumprimento {
+  cumprimento: string;
+  duracao?: number;
+  cor?: string;
+}
+
+declare function cumprimenta(setting: ConfiguracoesSaudacao): void;
+```
+
+## Tipos reutilizáveis (Tipo Aliases)
+
+_Documentação_
+
+> Em qualquer lugar que um cumprimento é esperado, você pode prover uma `string`, uma função retornando uma `string`, ou uma instancia de `Cumprimentador`.
+
+_Código_
+
+```ts
+function pegaCumprimento() {
+  return "oopa";
+}
+class MeuCumprimentador extends Cumprimentador {}
+
+cumprimenta("olá");
+cumprimenta(pegaCumprimento);
+cumprimenta(new MeuCumprimentador());
+```
+
+_Declaração_
+
+Você pode usar um alias para fazer uma abreviação para um tipo:
+
+```ts
+type ComoUmCumprimentador = string | (() => string) | MeuCumprimentador;
+
+declare function cumprimenta(g: ComoUmCumprimentador): void;
+```
+
+## Organizando Tipos
+
+_Documentação_
+
+> O objeto `cumprimentador` pode passar log para um arquivo ou mostrar um alerta.
+> Você pode prover LogOptions para `.log(...)` e opções de alerta para `.alert(...)`
+
+_Código_
+
+```ts
+const g = new Cumprimentador("Olá");
+g.log({ verbose: true });
+g.alert({ modal: false, title: "Cumprimento Atual" });
+```
+
+_Declaração_
+
+Use namespaces para organizar tipos.
+
+```ts
+declare namespace CumprimentoLib {
+  interface LogOptions {
+    verbose?: boolean;
+  }
+  interface AlertOptions {
+    modal: boolean;
+    title?: string;
+    color?: string;
+  }
+}
+```
+
+Voce também pode criar namespaces aninhados em uma declaração:
+
+```ts
+declare namespace CumprimentoLib.Options {
+  // Faz referência via CumprimentoLib.Options.Log
+  interface Log {
+    verbose?: boolean;
+  }
+  interface Alert {
+    modal: boolean;
+    title?: string;
+    color?: string;
+  }
+}
+```
+
+## Classes
+
+_Documentação_
+
+> Você pode criar um cumprimentador ao instanciar o objeto `Cumprimentador`, ou ao criar um cumprimentador customizado ao estendê-lo.
+
+_Código_
+
+```ts
+const MeuCumprimentador = new Cumprimentador("Olá, mundo");
+MeuCumprimentador.cumprimento = "oopa";
+MeuCumprimentador.mostraCumprimento();
+
+class CumprimentadorEspecial extends Cumprimentador {
+  constructor() {
+    super("Cumprimentador muito especial");
+  }
+}
+```
+
+_Declaração_
+
+Use `declare class` para descrever uma classe ou um objeto semelhante a classe.
+Classes também podem possuir propriedades e métodos assim como um construtor.
+
+```ts
+declare class Cumprimentador {
+  constructor(cumprimento: string);
+
+  cumprimento: string;
+  mostraCumprimento(): void;
+}
+```
+
+## Variáveis Globais
+
+_Documentação_
+
+> A variável global `foo` contém o numero de ferramentas atual. 
+
+_Código_
+
+```ts
+console.log("Metade do numero de ferramentas é " + foo / 2);
+```
+
+_Declaração_
+
+Use `declare var` para declarar variáveis.
+Se a variável é apenas-leitura, você pode usar `declare const`.
+Você também pode usar `declare let` se a variável é de escopo-fechado.
+
+```ts
+/** O numero de ferramentas atual */
+declare var foo: number;
+```
+
+## Global Functions
+
+_Documentação_
+
+> Você pode chamar a função `cumprimenta` com uma string para mostrar um cumprimento para o usuário.
+
+_Código_
+
+```ts
+cumprimenta("olá, mundo");
+```
+
+_Declaração_
+
+Use `declare function` para declarar funções.
+
+```ts
+declare function cumprimenta(cumprimento: string): void;
+```
+

--- a/docs/documentation/pt/declaration-files/Do's and Don'ts.md
+++ b/docs/documentation/pt/declaration-files/Do's and Don'ts.md
@@ -1,0 +1,241 @@
+---
+title: Do's and Don'ts
+layout: docs
+permalink: /pt/docs/handbook/declaration-files/do-s-and-don-ts.html
+oneline: "Recomendações para escrita de arquivos d.ts"
+---
+
+## Tipos Gerais
+
+## `Number`, `String`, `Boolean`, `Symbol` and `Object`
+
+_Nunca_ use os tipos `Number`, `String`, `Boolean`, `Symbol`, ou `Object`
+Esse tipos fazem referências a objetos não-primitivos que quase nunca são usados apropriadamente em códigos JavaScript.
+
+```ts
+/* Errado */
+function reverte(s: String): String;
+```
+
+_Sempre_ use os tipos `number`, `string`, `boolean`, e `symbol`.
+
+```ts
+/* OK */
+function reverte(s: string): string;
+```
+
+Ao invés de `Object`, use o tipo não-primitivo `object` ([adicionado em TypeScript 2.2](../release-notes/typescript-2-2.html#object-type)).
+
+## Generics
+
+_Nunca_ tenha um tipo genérico que não use os tipos de seus parâmetros.
+Veja mais detalhes em [TypeScript FAQ page](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-type-inference-work-on-this-interface-interface-foot--).
+
+## any
+
+_Nunca_ use `any` como tipo a não ser que você esteja no processo de migração do projeto de JavaScript para Typescript. O compilador _efetivamente_ trata `any` como "por favor desligue a verificação de tipo para essa coisa". Isso é similar a botar um comentário `@ts-ignore` em volta de cada uso da variável. Isso pode ser muito útil quando você está migrando pela primeira vez um projeto JavaScript para TypeScript pois pode definir o tipo para coisas que você ainda não migrou como `any`, mas em um projeto TypeScript completo você estará desabilitando a verificação de tipos para qualquer parte do seu programa que o use. 
+
+Em casos onde você não sabe o tipo você quer aceitar, ou quando quer aceitar qualquer coisa pois irá passar adiante cegamente sem interagir, você pode usar [`unknown`](/play/#example/unknown-and-never).
+
+
+<!-- TODO: More -->
+
+## Tipos de Callback
+
+## Tipos de Retorno e Callbacks
+
+<!-- TODO: Reword; these examples make no sense in the context of a declaration file -->
+
+_Nunca_ use o tipo de retorno `any` para callbacks cujo o valor será ignorado:
+
+```ts
+/* ERRADO */
+function fn(x: () => any) {
+  x();
+}
+```
+
+_Sempre_ use o tipo de retorno `void` para callbacks cujo o valor será ignorado:
+
+```ts
+/* OK */
+function fn(x: () => void) {
+  x();
+}
+```
+
+_Por quê?_: Usar void é mais seguro porque te previne de acidentalmente usar o valor de retorno de `x` de forma não verificada:
+
+```ts
+function fn(x: () => void) {
+  var k = x(); // oops! deveria fazer outra coisa
+  k.facaAlgo(); // erro, mas ficaria OK se o tipo retorno tivesse sido 'any'
+}
+```
+
+## Parâmetros Opcionais em Callbacks
+
+_Nunca_ use parâmetros opcionais em callbacks a não ser que você realmente tenha essa intenção:
+
+```ts
+/* ERRADO */
+interface Buscador {
+  retornaObjeto(pronto: (data: any, tempoDecorrido?: number) => void): void;
+}
+```
+
+Isso tem um significado muito especifico: o callback `pronto` pode ser invocado com 1 argumento ou pode ser invocado com 2 argumentos.
+O autor provavelmente teve a intenção de dizer que o callback talvez não se importe com o parâmetro `tempoDecorrido`, mas não tem necessidade de fazer o parâmetro opcional para atingir isso -- 
+sempre é valido prover um callback que aceita um numero menor de argumentos.
+
+_Sempre_ escreva parâmetros de callback como não-opcional: 
+
+```ts
+/* OK */
+interface Buscador {
+  retornaObjeto(pronto: (data: any, tempoDecorrido: number) => void): void;
+}
+```
+
+## Sobrecargas e Callbacks
+
+_Nunca_ escreva sobrecargas separadas que diferem apenas na aridade do callback:
+
+```ts
+/* ERRADO */
+declare function antesDeTodos(acao: () => void, timeout?: number): void;
+declare function antesDeTodos(
+  acao: (done: DoneFn) => void,
+  timeout?: number
+): void;
+```
+
+_Sempre_ escreva uma única sobrecarga usando a aridade maxima:
+
+```ts
+/* OK */
+declare function antesDeTodos(
+  acao: (done: DoneFn) => void,
+  timeout?: number
+): void;
+```
+
+_Por quê?_: Sempre é válido para um callback desprezar um parâmetro, então não tem necessidade de encurtar a sobrecarga.
+Provendo um callback mais curto primeiro permite funções incorretamente tipadas serem passadas adiante porque possuem correspondência com a primeira sobrecarga.
+
+## Sobrecargas de Funções
+
+## Ordenação
+
+_Nunca_ ponha sobrecargas genérias antes das mais específicas:
+
+```ts
+/* ERRADO */
+declare function fn(x: any): any;
+declare function fn(x: HTMLElement): number;
+declare function fn(x: HTMLDivElement): string;
+
+var meuElem: HTMLDivElement;
+var x = fn(meuElem); // x: any, quê?
+```
+
+_Sempre_ ordene sobrecargas pondo as assinaturas mais genéricas após as mais específicas: 
+
+```ts
+/* OK */
+declare function fn(x: HTMLDivElement): string;
+declare function fn(x: HTMLElement): number;
+declare function fn(x: any): any;
+
+var meuElem: HTMLDivElement;
+var x = fn(meuElem); // x: string, :)
+```
+
+_Por quê?_: TypeScript escolhe a _primeira sobrecarga com correspondência_ ao resolver chamadas as funções.
+Quando uma sobrecarga mais recente "é mais geral" do que uma mais antiga, a mais antiga é efetivamente omitida e não pode ser chamada.  
+
+## Use Parâmetros Opcionais
+
+_Nunca_ escreva muitas sobrecargas que diferem apenas em nos parâmetros finais:
+
+```ts
+/* ERRADO */
+interface Exemplo {
+  diff(um: string): number;
+  diff(um: string, dois: string): number;
+  diff(um: string, dois: string, tres: boolean): number;
+}
+```
+
+_Sempre_ que possível use parâmetros opcionais:
+
+```ts
+/* OK */
+interface Exemplo {
+  diff(um: string, dois?: string, tres?: boolean): number;
+}
+```
+
+Note que esse colapso deve ocorrer apenas quando todas as sobrecargas tiverem o mesmo tipo de retorno.
+
+
+_Por quê?_: Isso é importante por dois motivos.
+
+TypeScript resolve compatibilidade de assinaturas verificando se alguma assinatura do alvo pode ser chamada com os argumentos da fonte,_e argumentos estranhos são permitidos_.
+Esse código, por exemplo, expõe um bug apenas quando a assinatura é escrita corretamente usando parâmetros opcionais: 
+
+```ts
+function fn(x: (a: string, b: number, c: number) => void) {}
+var x: Exemplo;
+// Quando escrito com sobrecarga, OK -- usado a primeira sobrecarga
+// Quando escrito com opcionais, devidamente um erro
+fn(x.diff);
+```
+
+A segunda razão é quando um consumidor usa a funcionalidade "checagem estrita de nulos" do TypeScript.
+Porque parâmetros não especificados aparecem como `undefined` em javascript, geralmente é bom passar um `undefined` explícito para uma função com argumentos opcionais. 
+Esse código, por exemplo, deveria ser OK sob nulos estritos:
+
+```ts
+var x: Exemplo;
+// Quando escrito com sobrecargas,  um erro porque passa 'undefined' para 'string'
+// Quando escrito com opcionais, devidamente OK
+x.diff("algo", true ? undefined : "hora");
+```
+
+## Use Tipos de União
+
+_Nunca_ escreva sobrecargas que diferem por tipo em apenas um argumento:
+
+```ts
+/* ERRADO */
+interface Momento {
+  utcOffset(): number;
+  utcOffset(b: number): Momento;
+  utcOffset(b: string): Momento;
+}
+```
+
+_Sempre_ que possível use tipos de união:
+
+```ts
+/* OK */
+interface Momento {
+  utcOffset(): number;
+  utcOffset(b: number | string): Momento;
+}
+```
+
+Perceba que nós não fizemos `b` opcional aqui porque os tipos de retorno das assinaturas são diferentes.
+_Por quê?_: Isso é importante para pessoas que estão "passando adiante" um valor para sua função:
+
+```ts
+function fn(x: string): void;
+function fn(x: number): void;
+function fn(x: number | string) {
+  // Quando escrito com sobrecargas separadas, indevidamente um erro
+  // Quando escrito com tipos de união, 
+  // When written with union types, devidamente OK
+  return momento().utcOffset(x);
+}
+```


### PR DESCRIPTION
This PR translates the following documentation to Brazilian Portuguese.
 - Example.md
 - Do's and Dont's.md

### 📝 Notes:
I have translated Do's and Dont's to `Sempre` e `Nunca`. I know that it may look weird, but reads more natural in Portuguese.
Some exemples: 

> _Don't_ ever use the types `Number`, `String`, `Boolean`, `Symbol`, or `Object`

to

> _Nunca_ use os tipos `Number`, `String`, `Boolean`, `Symbol`, ou `Object`

Ref: #1 