### PR TITLE
Translate fr playground sections.json

### DIFF
--- a/docs/playground/fr/sections.json
+++ b/docs/playground/fr/sections.json
@@ -1,0 +1,85 @@
+{
+  "sections": [
+    {
+      "name": "JavaScript",
+      "id": "JavaScript",
+      "subtitle": "See how TypeScript improves day to day working with JavaScript with minimal additional syntax."
+    },
+    {
+      "name": "TypeScript",
+      "id": "TypeScript",
+      "subtitle": "Explore how TypeScript extends JavaScript to add more safety and tooling."
+    },
+    {
+      "name": "3.7",
+      "id": "3.7",
+      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/'>Release notes</a>."
+    },
+    {
+      "name": "3.8",
+      "id": "3.8",
+      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/'>Release notes</a>."
+    },
+    {
+      "name": "4.0",
+      "id": "4.0",
+      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/'>Release notes</a>."
+    },
+    {
+      "name": "4.1",
+      "id": "4.1",
+      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/'>Release notes</a>."
+    },
+    {
+      "name": "4.2",
+      "id": "4.2",
+      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-2-beta/'>Release notes</a>."
+    },
+    {
+      "name": "4.3",
+      "id": "4.3",
+      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-3/'>Release notes</a>."
+    },
+    {
+      "name": "4.4",
+      "id": "4.4",
+      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/'>Release notes</a>."
+    },
+    {
+      "name": "Playground V3",
+      "id": "Playground",
+      "subtitle": "Learn what has changed in this website."
+    }
+  ],
+  "sortedSubSections": [
+    // JS
+    "JavaScript Essentials",
+    "Functions with JavaScript",
+    "Working With Classes",
+    "Modern JavaScript",
+    "External APIs",
+    "Helping with JavaScript",
+    // TS
+    "Primitives",
+    "Type Primitives",
+    "Meta-Types",
+    "Language",
+    "Language Extensions",
+    // Examples
+    "Syntax and Messaging",
+    "Types and Code Flow",
+    "Fixits",
+    // Playground
+    "Config",
+    "Tooling",
+    // 3.8
+    "Breaking Changes",
+    "JSDoc Improvements",
+    // 4.0
+    "New JS Features",
+    "New TS Features",
+    "New Checks",
+    // 4.1
+    "Template Literals"
+  ]
+}

--- a/docs/playground/fr/sections.json
+++ b/docs/playground/fr/sections.json
@@ -3,83 +3,83 @@
     {
       "name": "JavaScript",
       "id": "JavaScript",
-      "subtitle": "See how TypeScript improves day to day working with JavaScript with minimal additional syntax."
+      "subtitle": "Voyez comment TypeScript facilite le travail du quotidien en JavaScript avec le minimum de syntaxe additionnelle."
     },
     {
       "name": "TypeScript",
       "id": "TypeScript",
-      "subtitle": "Explore how TypeScript extends JavaScript to add more safety and tooling."
+      "subtitle": "Explorez comment TypeScript étend JavaScript en ajoutant de la sécuritée et des outils à votre code."
     },
     {
       "name": "3.7",
       "id": "3.7",
-      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/'>Release notes</a>."
+      "subtitle": "Voir les <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/'>notes de version</a>."
     },
     {
       "name": "3.8",
       "id": "3.8",
-      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/'>Release notes</a>."
+      "subtitle": "Voir les <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/'>notes de version</a>."
     },
     {
       "name": "4.0",
       "id": "4.0",
-      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/'>Release notes</a>."
+      "subtitle": "Voir les <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/'>notes de version</a>."
     },
     {
       "name": "4.1",
       "id": "4.1",
-      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/'>Release notes</a>."
+      "subtitle": "Voir les <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/'>notes de version</a>."
     },
     {
       "name": "4.2",
       "id": "4.2",
-      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-2-beta/'>Release notes</a>."
+      "subtitle": "Voir les <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-2-beta/'>notes de version</a>."
     },
     {
       "name": "4.3",
       "id": "4.3",
-      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-3/'>Release notes</a>."
+      "subtitle": "Voir les <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-3/'>notes de version</a>."
     },
     {
       "name": "4.4",
       "id": "4.4",
-      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/'>Release notes</a>."
+      "subtitle": "Voir les <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/'>notes de version</a>."
     },
     {
       "name": "Playground V3",
       "id": "Playground",
-      "subtitle": "Learn what has changed in this website."
+      "subtitle": "Voyez ce qui a changé sur ce site."
     }
   ],
   "sortedSubSections": [
     // JS
-    "JavaScript Essentials",
-    "Functions with JavaScript",
-    "Working With Classes",
-    "Modern JavaScript",
-    "External APIs",
-    "Helping with JavaScript",
+    "Fondamentaux JavaScript",
+    "Les fonctions en JavaScript",
+    "Utiliser les classes",
+    "JavaScript moderne",
+    "APIs externes",
+    "Aide pour le JavaScript",
     // TS
     "Primitives",
-    "Type Primitives",
+    "Types primitifs",
     "Meta-Types",
-    "Language",
-    "Language Extensions",
+    "Langage",
+    "Extensions du langage",
     // Examples
-    "Syntax and Messaging",
-    "Types and Code Flow",
+    "Syntaxe et messages",
+    "Types et flux de code",
     "Fixits",
     // Playground
-    "Config",
-    "Tooling",
+    "Configuration",
+    "Outillage",
     // 3.8
-    "Breaking Changes",
-    "JSDoc Improvements",
+    "Modifications avec rupture",
+    "Amélioration de JSDoc",
     // 4.0
-    "New JS Features",
-    "New TS Features",
-    "New Checks",
+    "Nouvelles fonctionnalités JS",
+    "Nouvelles fonctionnalités TS",
+    "Nouvelles vérifications",
     // 4.1
-    "Template Literals"
+    "Littéraux de gabarits"
   ]
 }

--- a/docs/playground/fr/sections.json
+++ b/docs/playground/fr/sections.json
@@ -8,7 +8,7 @@
     {
       "name": "TypeScript",
       "id": "TypeScript",
-      "subtitle": "Explorez comment TypeScript étend JavaScript en ajoutant de la sécuritée et des outils à votre code."
+      "subtitle": "Explorez comment TypeScript étend JavaScript en ajoutant de la sécurité et des outils à votre code."
     },
     {
       "name": "3.7",
@@ -68,7 +68,7 @@
     // Examples
     "Syntaxe et messages",
     "Types et flux de code",
-    "Fixits",
+    "Correction automatique",
     // Playground
     "Configuration",
     "Outillage",


### PR DESCRIPTION
Taking the first item on the list of https://github.com/microsoft/TypeScript-Website-Localizations/issues/100.

Comments / questions :
- original strings are Title Cased - which seems common in English, but is not common in French so I've not title cased the translated strings
- Couldn't come up with something nice for "Fixits", as it's a TS thing it might be ok to leave the original term ?
- The translation for "Template Literals" comes from [MDN](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Template_literals)