### PR TITLE
Translate to FR: typescriptlang directory

### DIFF
--- a/docs/typescriptlang/fr/dt.ts
+++ b/docs/typescriptlang/fr/dt.ts
@@ -1,0 +1,19 @@
+export const dtCopy = {
+  dt_s_page_title: "Rechercher des paquets typés",
+  dt_s_title: "Rechercher un paquet",
+  dt_s_subtitle:
+    "Trouver des paquets npm qui ont des déclarations de types, soit intégrés ou sur Definitely Typed.",
+  dt_s_match: "résultat",
+  dt_s_matchs: "résultats",
+  dt_s_match_exact: "Résultat exact",
+  dt_s_popular_on_dt: "Populaire sur Definitely Typed",
+  dt_s_downloads_short: "DLs",
+  dt_s_downloads_via: "Via",
+  dt_s_module: "Module",
+  dt_s_last_update: "Dernière mise à jour",
+  dt_s_install: "Installer",
+  dt_s_no_results: "Aucun résultat trouvé pour",
+  dt_s_no_results_try: "Essayez une autre recherche ?",
+  dt_s_copy: "copier",
+  dt_s_copied: "copié",
+};

--- a/docs/typescriptlang/fr/fr.ts
+++ b/docs/typescriptlang/fr/fr.ts
@@ -1,0 +1,16 @@
+import { defineMessages } from "react-intl";
+import { Copy, messages as englishMessages } from "../en/en";
+import { comCopy } from "./community";
+import { dtCopy } from "./dt";
+import { handbookCopy } from "./handbook";
+import { headCopy } from "./head-seo";
+import { navCopy } from "./nav";
+
+export const lang: Copy = defineMessages({
+  ...englishMessages,
+  ...comCopy,
+  ...dtCopy,
+  ...handbookCopy,
+  ...headCopy,
+  ...navCopy,
+});

--- a/docs/typescriptlang/fr/handbook.ts
+++ b/docs/typescriptlang/fr/handbook.ts
@@ -1,0 +1,13 @@
+export const handbookCopy = {
+  handb_prev: "Précédent",
+  handb_next: "Suivant",
+  handb_on_this_page: "Dans cette page",
+  handb_like_dislike_title: "Cette page est-elle utile ?",
+  handb_like_desc: "Oui",
+  handb_dislike_desc: "Non",
+  handb_thanks: "Merci pour votre retour",
+  handb_deprecated_title: "Cette page a été dépréciée",
+  handb_deprecated_subtitle: "Cette page du guide a été remplacé, ",
+  handb_deprecated_subtitle_link: "aller à la nouvelle page",
+  handb_deprecated_subtitle_action: "Aller à la nouvelle page",
+};

--- a/docs/typescriptlang/fr/head-seo.ts
+++ b/docs/typescriptlang/fr/head-seo.ts
@@ -1,0 +1,14 @@
+export const headCopy = {
+  head_playground_title:
+    "TS Playground - Un éditeur en ligne pour explorer TypeScript et JavaScript",
+  head_playground_description:
+    "Playground vous permet d'écrire du TypeScript ou du JavaScript en ligne de manière sûre et partageable.",
+  tsconfig_title:
+    "Référence TSConfig - documentation sur toutes les options du fichier TSConfig",
+  tsconfig_description:
+    "De allowJs à useDefineForClassFields, la référence TSConfig documente les différents options du compilateur qui permettent de configurer un projet TypeScript.",
+  playground_example_prefix: "Playground Exemple - ",
+
+  head_index_title: "JavaScript typé à toute échelle",
+  head_index_description: "JavaScript typé à toute échelle",
+};

--- a/docs/typescriptlang/fr/nav.ts
+++ b/docs/typescriptlang/fr/nav.ts
@@ -1,0 +1,22 @@
+export const navCopy = {
+  skip_to_content: "Aller au contenu principal",
+  nav_documentation: "Documentation",
+  nav_documentation_short: "Docs",
+  nav_download: "Télécharger",
+  nav_community: "Communauté",
+  nav_playground: "Playground",
+  nav_playground_short: "Play",
+  nav_handbook: "Guide",
+  nav_tools: "Outils",
+  nav_search_placeholder: "Rechercher",
+  nav_search_aria: "Recherche sur le site TypeScript",
+  // let me know if you can't make this work in your lang:
+  // TypeScript X.Y [stable][between?]Z.Y[beta/rc]
+  nav_version_stable_prefix: "est maintenant disponible",
+  nav_version_between: ", ",
+  nav_version_beta_prefix: "est actuellement en bêta.",
+  nav_version_rc_prefix: "est une version candidate, essayer la.",
+  nav_this_page_in_your_lang: "Cette page est disponible dans votre langue",
+  nav_this_page_in_your_lang_open: "Ouvrir",
+  nav_this_page_in_your_lang_no_more: "Ne plus montrer",
+};


### PR DESCRIPTION
Le lien vers les fichiers en Anglais -> [microsoft/TypeScript-Website](https://github.com/microsoft/TypeScript-Website/tree/v2/packages/typescriptlang-org/src/copy/en)

J'ai traduit `handbook` par `Guide`, je ne me voyais pas mettre documentation/doc. J'ai laissé playground en anglais... Je ne sais pas quoi mettre (`éditeur en ligne` ou `éditeur` tout simplement peut etre)