### PR TITLE
FR translation: fix typo

### DIFF
--- a/docs/playground/fr/3-7/Syntax and Messaging/Optional Chaining.ts
+++ b/docs/playground/fr/3-7/Syntax and Messaging/Optional Chaining.ts
@@ -8,7 +8,8 @@
 // Accès aux propriétés d'un objet
 
 // Imaginons que nous ayons un album où l'artiste, et sa bio, puissent ne pas
-// être present dans les données. Par exemple, une compilation pourrait n'aurait pas un seul artiste.
+// être present dans les données. Par exemple, une compilation pourrait ne pas
+// avoir qu'un seul artiste.
 
 type AlbumAPIResponse = {
   title: string;


### PR DESCRIPTION
Fix some missing words. See [comment](https://github.com/microsoft/TypeScript-Website-Localizations/pull/114#discussion_r684650542)