### PR TITLE
Translate 1 file to ko - Uncalled Function Checks

### DIFF
--- a/docs/playground/ko/3-7/Types and Code Flow/Uncalled Function Checks.ts
+++ b/docs/playground/ko/3-7/Types and Code Flow/Uncalled Function Checks.ts
@@ -1,0 +1,41 @@
+//// { compiler: {  }, order: 1 }
+
+// 3.7에서는 if문 안에서
+// 함수의 반환 값 대신 함수를 잘못 사용하는 것을
+// 검사하는 기능이 추가되었습니다.
+
+// 이것은 함수가 존재하는 것을 알고 있으며
+// if문을 항상 참으로 할 때만 적용됩니다.
+
+// 선택적인 콜백과, 선택적이지 않은 콜백이 있는
+// 플러그인 인터페이스의 예시입니다.
+
+interface PluginSettings {
+  pluginShouldLoad?: () => void;
+  pluginIsActivated: () => void;
+}
+
+declare const plugin: PluginSettings;
+
+// pluginShouldLoad가 존재하지 않을 수 있으므로,
+// 다음 검사는 타당합니다.
+
+if (plugin.pluginShouldLoad) {
+  // pluginShouldLoad가 존재할 때의 처리.
+}
+
+// 이는 3.6 이전에서 에러가 아니었습니다.
+
+if (plugin.pluginIsActivated) {
+  // 플러그인이 활성화되었을 때 무언가를 처리하려고 하는데,
+  // 메서드를 호출하는 대신
+  // 프로퍼티로 사용했습니다.
+}
+
+// pluginIsActivated는 언제나 존재하겠지만,
+// if 블록 안에서 메서드가 호출되고 있으므로
+// TypeScript는 검사를 허용하고 있습니다.
+
+if (plugin.pluginIsActivated) {
+  plugin.pluginIsActivated();
+}


### PR DESCRIPTION
#6 

Uncalled Function Checks를 번역하였습니다. 검수 부탁드립니다.

@yeonjuan
추가적으로, 용어집에 '블록'이 추가되면 좋을 것 같습니다. 자주 등장할 것 같은 단어인 것 같습니다.
국립국어원 발음표기에 따라 '블락', '블럭'이 아닌 '블록'으로 표현하는 것이 옳다고 합니다.