### PR TITLE
Fix typo in korean documentation

### DIFF
--- a/docs/documentation/ko/javascript/Creating DTS files From JS.md
+++ b/docs/documentation/ko/javascript/Creating DTS files From JS.md
@@ -73,7 +73,7 @@ TypeScript는 .d.ts 파일을 찾기 위한 추가 단계와 함께 `package.jso
 | :------------------------ | :----------------------------- |
 | "types" 필드 없음           | "main" 확인 후, index.d.ts 확인   |
 | "types": "main.d.ts"      | main.d.ts                      |
-| "types": "./dist/main.js" | ./main/main.d.ts               |
+| "types": "./dist/main.js" | ./dist/main.d.ts               |
 
 type 필드가 없다면, "main"으로 넘어갑니다.
 


### PR DESCRIPTION
I found a typo in [document](https://www.typescriptlang.org/ko/docs/handbook/declaration-files/dts-from-js.html#packagejson-수정-editing-the-packagejson).

As I compare with English document, `./main/main.d.ts` should be `./dist/main.d.ts`.

As-is: 
| Package.json              | 기본 .d.ts의 위치                 |
| :------------------------ | :----------------------------- |
| "types" 필드 없음           | "main" 확인 후, index.d.ts 확인   |
| "types": "main.d.ts"      | main.d.ts                      |
| "types": "./dist/main.js" | **_./main/main.d.ts_**               |

To-be:
| Package.json              | 기본 .d.ts의 위치                 |
| :------------------------ | :----------------------------- |
| "types" 필드 없음           | "main" 확인 후, index.d.ts 확인   |
| "types": "main.d.ts"      | main.d.ts                      |
| "types": "./dist/main.js" | **_./dist/main.d.ts_**               |

Please check my PR and give some feedback if I did something wrong.

Thanks!

