### PR TITLE
Remove span tag in title and unnecessary TOC in Ko

### DIFF
--- a/docs/documentation/ko/release-notes/TypeScript 3.8.md
+++ b/docs/documentation/ko/release-notes/TypeScript 3.8.md
@@ -5,15 +5,7 @@ permalink: /ko/docs/handbook/release-notes/typescript-3-8.html
 oneline: TypeScript 3.8 Release Notes
 ---
 
-* [타입-전용 Imports 와 Exports](#type-only-imports-exports)
-* [ECMAScript 비공개 필드](#ecmascript-private-fields)
-* [`export * as ns` 구문](#export-star-as-namespace-syntax)
-* [최상위-레벨 `await`](#top-level-await)
-* [JSDoc 프로퍼티 지정자](#jsdoc-modifiers)
-* [리눅스에서 더 나은 디렉터리 감시와 `watchOptions`](#better-directory-watching)
-* ["빠르고 느슨한" 증분 검사](#assume-direct-dependencies)
-
-## <span id="type-only-imports-exports" /> 타입-전용 Imports 와 Exports (Type-Only Imports and Exports)
+## 타입-전용 Imports 와 Exports (Type-Only Imports and Exports)
 
 이 기능은 대부분의 사용자에겐 생각할 필요가 없을 수도 있지만; `--isolatedModules`, TypeScript의 `transpileModule` API, 또는 Babel에서 문제가 발생하면 이 기능과 관련이 있을 수 있습니다.
 
@@ -68,7 +60,7 @@ import type Foo, { Bar, Baz } from "some-module";
 
 이 기능에 대한 더 자세한 정보는, `import type`선언이 사용될수 있는 범위를 확대하는 [pull request](https://github.com/microsoft/TypeScript/pull/35200), 와 [관련된 변경 사항](https://github.com/microsoft/TypeScript/pull/36092/)에서 찾을 수 있습니다.
 
-## <span id="ecmascript-private-fields" /> ECMAScript 비공개 필드 (ECMAScript Private Fields)
+## ECMAScript 비공개 필드 (ECMAScript Private Fields)
 
 TypeScript 3.8 은 ECMAScript의 [stage-3 클래스 필드 제안](https://github.com/tc39/proposal-class-fields/)의 비공개 필드를 지원합니다.
 
@@ -269,7 +261,7 @@ TypeScript의 `private`프로퍼티 선언에서는, 사용자는 여전히 상�
 반면에, `#` 비공개 필드는 `WeakMap`을 이용해 다운 레벨 되기 때문에 사용 속도가 느려질 수 있습니다.
 어떤 런타임은 `#` 비공개 필드 구현을 최적화 하고, 더 빠른 `WeakMap`을 구현하고 싶을 수 있지만, 모든 런타임에서 그렇지 않을 수 있습니다.
 
-## <span id="export-star-as-namespace-syntax" /> `export * as ns` 구문 (`export * as ns` Syntax)
+## `export * as ns` 구문 (`export * as ns` Syntax)
 
 다른 모듈의 모든 멤버를 하나의 멤버로 내보내는 단일 진입점을 갖는 것은 종종 일반적입니다.
 
@@ -287,7 +279,7 @@ export * as utilities from "./utilities.js";
 이것은 JavaScript에 대한 훌륭한 삶의 질의 향상이며, TypeScript 3.8은 이 구문을 지원합니다.
 모듈 대상이 `es2020` 이전인 경우, TypeScript는 첫 번째 줄의 코드 스니펫을 따라서 무언가를 출력할 것입니다.
 
-## <span id="top-level-await" /> 최상위-레벨 `await` (Top-Level `await`)
+## 최상위-레벨 `await` (Top-Level `await`)
 
 TypeScript 3.8은 "최상위-레벨 `await`"이라는 편리한 ECMAScript 기능을 지원합니다.
 
@@ -325,13 +317,13 @@ export {};
 
 구현에 관한 더 자세한 정보는 [the original pull request을 확인하세요](https://github.com/microsoft/TypeScript/pull/35813).
 
-## <span id="es2020-for-target-and-module" /> `es2020`용 `target`과 `module`   (`es2020` for `target` and `module`)
+## `es2020`용 `target`과 `module`   (`es2020` for `target` and `module`)
 
 TypeScript 3.8은 `es2020`을 `module`과 `target` 옵션으로 지원합니다.
 이를 통해 선택적 체이닝 (optional chaining), nullish 병합 (nullish coalescing), `export * as ns` 그리고 동적인 `import(...)` 구문과 같은 ECMAScript 2020 기능이 유지됩니다.
 또한 `bigint` 리터럴이 `esnext` 아래에 안정적인 `target`을 갖는 것을 의미합니다.
 
-## <span id="jsdoc-modifiers" /> JSDoc 프로퍼티 지정자 (JSDoc Property Modifiers)
+## JSDoc 프로퍼티 지정자 (JSDoc Property Modifiers)
 
 TypeScript 3.8는 `allowJs` 플래그를 사용하여 JavaScript 파일을 지원하고 `checkJs` 옵션이나 `// @ts-check` 주석을 `.js` 파일 맨 위에 추가하여 JavaScript 파일의 *타입-검사*를 지원합니다.
 
@@ -387,7 +379,7 @@ new Foo().stuff++;
 // 'stuff'는 읽기-전용(read-only) 프로퍼티이기 때문에 할당할 수 없습니다.
 ```
 
-## <span id="better-directory-watching" /> 리눅스에서 더 나은 디렉터리 감시와 `watchOptions`
+## 리눅스에서 더 나은 디렉터리 감시와 `watchOptions`
 
 TypeScript 3.8에서는 `node_modules`의 변경사항을 효율적으로 수집하는데 중요한 새로운 디렉터리 감시 전략을 제공합니다.
 
@@ -441,7 +433,7 @@ TypeScript의 이전 버전은 폴더에 디렉터리 왓쳐를 *즉시* 설치�
 
 이 변경의 더 자세한 내용은 Github으로 이동하여 [the pull request](https://github.com/microsoft/TypeScript/pull/35615)를 읽어보세요.
 
-## <span id="assume-direct-dependencies" /> "빠르고 느슨한" 증분 검사
+## "빠르고 느슨한" 증분 검사
 
 TypeScript 3.8은 새로운 컴파일러 옵션 `assumeChangesOnlyAffectDirectDepencies`을 제공합니다.
 이 옵션이 활성화되면, TypeScript는 정말로 영향을 받은 파일들은 재검사/재빌드하지않고, 변경된 파일뿐만 아니라 직접 import 한 파일만 재검사/재빌드 합니다.

--- a/docs/documentation/ko/release-notes/TypeScript 3.9.md
+++ b/docs/documentation/ko/release-notes/TypeScript 3.9.md
@@ -5,18 +5,7 @@ permalink: /ko/docs/handbook/release-notes/typescript-3-9.html
 oneline: TypeScript 3.9 Release Notes
 ---
 
-* [추론과 `Promise.all` 개선](#improvements-in-inference-and-promiseall)
-* [속도 향상](#speed-improvements)
-* [`// @ts-expect-error` 주석](#-ts-expect-error-comments)
-* [조건문에서 호출되지 않은 함수 체크](#uncalled-function-checks-in-conditional-expressions)
-* [에디터 개선](#editor-improvements)
-    * [JavaScript에서 CommonJS 자동-Imports](#commonjs-auto-imports-in-javascript)
-    * [코드 작업 개행 유지](#code-actions-preserve-newlines)
-    * [누락된 반환문 빠른 수정](#quick-fixes-for-missing-return-expressions)
-    * [`tsconfig.json` 파일 "솔루션 스타일" 지원](#support-for-solution-style-tsconfigjson-files)
-* [주요 변경 사항](#주요-변경-사항-breaking-changes)
-
-## <span id="improvements-in-inference-and-promiseall" /> 추론과 `Promise.all` 개선 (Improvements in Inference and `Promise.all`)
+## 추론과 `Promise.all` 개선 (Improvements in Inference and `Promise.all`)
 
 최신 버전의 TypeScript(약 3.7)는 `Promise.all` 및 `Promise.race`와 같은 함수 선언이 업데이트되었습니다.
 안타깝게도, 특히 `null` 또는 `undefined`와 값을 혼합할 때, 약간의 회귀가 발생했습니다.
@@ -54,7 +43,7 @@ async function visitZoo(lionExhibit: Promise<Lion>, sealExhibit: Promise<Seal | 
 결과적으로, 더 확실해질 때까지 메인 브랜치에서 이 기능을 빼기로 결정했습니다.
 이 기능에 대해 더 많은 실험을 할 예정이지만, 이번 릴리스에서는 제공하지 않습니다.
 
-## <span id="speed-improvements" /> 속도 향상 (Speed Improvements)
+## 속도 향상 (Speed Improvements)
 
 TypeScript 3.9는 많은 새로운 속도 향상 기능이 포함되어 있습니다.
 우리 팀은 material-ui 및 styled-components와 같은 패키지를 사용할 때 편집 / 컴파일 속도가 매우 열악한 것을 확인한 후 성능에 중점을 두었습니다.
@@ -76,7 +65,7 @@ TypeScript 3.9는 [컴파일러 및 언어 서비스가 파일 조회를 캐싱 
 
 여전히 개선의 여지가 있지만, 이 작업이 모든 사람들에게 보다 빠른 경험으로 이어지기를 바랍니다!
 
-## <span id="-ts-expect-error-comments" /> `// @ts-expect-error` 주석 (`// @ts-expect-error` Comments)
+## `// @ts-expect-error` 주석 (`// @ts-expect-error` Comments)
 
 TypeScript로 라이브러리를 작성하고 퍼블릭 API의 일부분으로 `doStuff`라는 함수를 export 한다고 상상해보세요.
 TypeScript 사용자가 타입-체크 오류를 받을 수 있도록 `doStuff` 함수의 타입은 두 개의 `string`을 갖는다고 선언하지만, 또한 JavaScript 사용자에게 유용한 오류를 제공하기 위해 런타임 오류 체크를 합니다 (개발 빌드 시에만 가능).
@@ -154,7 +143,7 @@ Unused '@ts-expect-error' directive.
 * TypeScript의 두 가지 버전 사이에서 업그레이드하는 중이고, 한 버전에서는 코드 오류가 발생하지만 나머지 버전에서는 그렇지 않은 경우
 * 솔직히 어떤 옵션 더 나은지 결정할 시간이 없는 경우
 
-## <span id="uncalled-function-checks-in-conditional-expressions" /> 조건문에서 호출되지 않은 함수 체크 (Uncalled Function Checks in Conditional Expressions)
+## 조건문에서 호출되지 않은 함수 체크 (Uncalled Function Checks in Conditional Expressions)
 
 TypeScript 3.7에서 함수 호출을 잊어버렸을 경우 오류를 보고하기 위해 *호출되지 않은 함수 체크*를 도입했습니다.
 
@@ -198,7 +187,7 @@ function getAllFiles(startFileName: string) {
 
 https://github.com/microsoft/TypeScript/issues/36048
 
-## <span id="editor-improvements" /> 에디터 개선 (Editor Improvements)
+## 에디터 개선 (Editor Improvements)
 
 TypeScript 컴파일러는 주요 에디터의 TypeScript 작성 경험뿐만 아니라, Visual Studio 계열 에디터의 JavaScript 작성 경험에도 영향을 줍니다.
 에디터에서 새로운 TypeScript/JavaScript 기능을 사용하는 것은 에디터에 따라 다르겠지만
@@ -207,7 +196,7 @@ TypeScript 컴파일러는 주요 에디터의 TypeScript 작성 경험뿐만 �
 * Visual Studio 2017/2019 에는 [SDK 설치 프로그램] 과 [MSBuild 설치](https://www.nuget.org/packages/Microsoft.TypeScript.MSBuild)가 있습니다.
 * Sublime Text 3은 [다른 버전의 TypeScript 선택]((https://github.com/microsoft/TypeScript-Sublime-Plugin#note-using-different-versions-of-typescript))을 지원합니다.
 
-### <span id="commonjs-auto-imports-in-javascript" /> JavaScript에서 CommonJS 자동-import (CommonJS Auto-Imports in JavaScript)
+### JavaScript에서 CommonJS 자동-import (CommonJS Auto-Imports in JavaScript)
 
 CommonJS 모듈을 사용하는 JavaScript 파일에서 자동-import 기능이 크게 개선되었습니다.
 
@@ -230,7 +219,7 @@ const fs = require("fs");
 
 이 변경에 대한 자세한 내용은, [해당 pull request](https://github.com/microsoft/TypeScript/pull/37027)를 참고하세요.
 
-### <span id="code-actions-preserve-newlines" /> 코드 작업 개행 유지 (Code Actions Preserve Newlines)
+### 코드 작업 개행 유지 (Code Actions Preserve Newlines)
 
 TypeScript의 리팩터링과 빠른 수정은 종종 개행을 유지하는데 큰 역할을 하지는 않았습니다.
 기본적인 예로 다음 코드를 보겠습니다.
@@ -291,7 +280,7 @@ function printSquares() {
 
 [이 pull request](https://github.com/microsoft/TypeScript/pull/36688)에서 구현에 대해 더 자세히 볼 수 있습니다.
 
-### <span id="quick-fixes-for-missing-return-expressions" /> 누락된 반환 문 빠른 수정 (Quick Fixes for Missing Return Expressions)
+### 누락된 반환 문 빠른 수정 (Quick Fixes for Missing Return Expressions)
 
 특히 화살표 함수에 중괄호를 추가할 때, 함수의 마지막 문의 값을 반환하는 것을 잊는 경우가 있습니다.
 
@@ -307,7 +296,7 @@ let f2 = () => { 42 }
 
 ![TypeScript는 `return` 문을 추가하거나 중괄호를 제거하여 식이 반환되지 않는 오류를 수정합니다.](https://devblogs.microsoft.com/typescript/wp-content/uploads/sites/11/2020/04/missingReturnValue-3-9.gif)
 
-### <span id="support-for-solution-style-tsconfigjson-files" /> `tsconfig.json` 파일 "솔루션 스타일" 지원 (Support for "Solution Style" `tsconfig.json` Files)
+### `tsconfig.json` 파일 "솔루션 스타일" 지원 (Support for "Solution Style" `tsconfig.json` Files)
 
 에디터는 파일이 어떤 설정 파일에 속하는지 파악하여 적절한 옵션을 적용할 수 있도록 하고 현재 "프로젝트"에 어떤 다른 파일이 포함되어 있는지 파악해야 합니다.
 기본적으로, TypeScript의 언어 서버가 영향을 주는 에디터는 각 상위 디렉터리를 따라 올라가 `tsconfig.json`을 찾음으로써 이 작업을 수행합니다.


### PR DESCRIPTION
In the Korean release notes document, toc malfunctions due to unnecessary span tags.

- https://www.typescriptlang.org/ko/docs/handbook/release-notes/typescript-3-8.html

<img width="201" alt="스크린샷 2022-08-14 오후 3 31 35" src="https://user-images.githubusercontent.com/53500778/184525386-1a39c623-dff0-4a84-a921-2c5c92ee867f.png">

- https://www.typescriptlang.org/ko/docs/handbook/release-notes/typescript-3-9.html
<img width="190" alt="스크린샷 2022-08-14 오후 3 31 40" src="https://user-images.githubusercontent.com/53500778/184525388-123340c5-b9de-4c46-8401-e42373b31930.png">
