### PR TITLE
fix: fix branch link 'master' to 'main'

### DIFF
--- a/docs/documentation/id/Nightly Builds.md
+++ b/docs/documentation/id/Nightly Builds.md
@@ -6,7 +6,7 @@ oneline: Cara menggunakan nightly build TypeScript
 translatable: true
 ---
 
-_Nightly build_ dari _branch_ [master TypeScript](https://github.com/Microsoft/TypeScript/tree/master) diterbitkan pada tengah malam, di zona waktu PST ke npm.
+_Nightly build_ dari _branch_ [main TypeScript](https://github.com/Microsoft/TypeScript/tree/main) diterbitkan pada tengah malam, di zona waktu PST ke npm.
 Berikut adalah cara untuk mendapatkan versi ini dan cara menggunakannya.
 
 ## Menggunakan npm

--- a/docs/documentation/ja/Nightly Builds.md
+++ b/docs/documentation/ja/Nightly Builds.md
@@ -6,7 +6,7 @@ oneline: TypeScriptのナイトリービルドを使うには
 translatable: true
 ---
 
-ナイトリービルドは、[TypeScriptの`master`](https://github.com/Microsoft/TypeScript/tree/master)ブランチからビルドされて、PST深夜0時までにnpmに公開されています。
+ナイトリービルドは、[TypeScriptの`main`](https://github.com/Microsoft/TypeScript/tree/main)ブランチからビルドされて、PST深夜0時までにnpmに公開されています。
 これを入手してご自身のツールで利用する手順は次のとおりです。
 
 ## npmを使う

--- a/docs/documentation/ko/Nightly Builds.md
+++ b/docs/documentation/ko/Nightly Builds.md
@@ -6,7 +6,7 @@ oneline: How to use a nightly build of TypeScript
 translatable: true
 ---
 
-[TypeScript의 `master`](https://github.com/Microsoft/TypeScript/tree/master) 브랜치의 nightly 빌드는 태평양 표준시(PST) 자정까지 NPM에 배포됩니다.  
+[TypeScript의 `main`](https://github.com/Microsoft/TypeScript/tree/main) 브랜치의 nightly 빌드는 태평양 표준시(PST) 자정까지 NPM에 배포됩니다.  
 도구를 사용하여 가져오는 방법과 사용하는 방법은 다음과 같습니다.
 
 ## npm 사용하기 (Using npm)

--- a/docs/documentation/pl/Nightly Builds.md
+++ b/docs/documentation/pl/Nightly Builds.md
@@ -6,7 +6,7 @@ oneline: Jak korzystać z nocnej kompilacji języka TypeScript
 translatable: true
 ---
 
-Nocna kompilacja z gałęzi „master” [TypeScript](https://github.com/Microsoft/TypeScript/tree/master) jest publikowana o północy czasu PST do npm.
+Nocna kompilacja z gałęzi „main” [TypeScript](https://github.com/Microsoft/TypeScript/tree/main) jest publikowana o północy czasu PST do npm.
 Oto, jak możesz go pobrać i używać ze swoimi narzędziami.
 
 ## Używając npm

--- a/docs/documentation/pt/Nightly Builds.md
+++ b/docs/documentation/pt/Nightly Builds.md
@@ -6,7 +6,7 @@ oneline: Como usar uma compilação noturna de TypeScript
 translatable: true
 ---
 
-Uma compilação noturna da branch [`master` do TypeScript](https://github.com/Microsoft/TypeScript/tree/master) é publicada à meia-noite PST no npm.
+Uma compilação noturna da branch [`main` do TypeScript](https://github.com/Microsoft/TypeScript/tree/main) é publicada à meia-noite PST no npm.
 Veja como você pode obtê-la e usá-la com suas ferramentas.
 
 ## Usando o npm

--- a/docs/documentation/zh/Nightly Builds.md
+++ b/docs/documentation/zh/Nightly Builds.md
@@ -6,7 +6,7 @@ oneline: 如何使用TypeScript的每日构建版本
 translatable: true
 ---
 
-在太平洋标准时间的每日午夜，TypeScript 代码仓库中[master 分支](https://github.com/Microsoft/TypeScript/tree/master)上的代码会自动构建并发布到 npm 上。
+在太平洋标准时间的每日午夜，TypeScript 代码仓库中[main 分支](https://github.com/Microsoft/TypeScript/tree/main)上的代码会自动构建并发布到 npm 上。
 下面将介绍如何获取并结合你的工具来使用它。
 
 ## 使用 npm

--- a/docs/tsconfig/it/options/lib.md
+++ b/docs/tsconfig/it/options/lib.md
@@ -67,4 +67,4 @@ Potresti volerli cambiare per alcuni motivi:
 | `ESNext.Symbol`           |  
 
 
-Questa lista potrebbe non essere aggiornata, puoi vedere la lista completa nel [codice sorgente di TypeScript](https://github.com/microsoft/TypeScript/tree/master/lib).
+Questa lista potrebbe non essere aggiornata, puoi vedere la lista completa nel [codice sorgente di TypeScript](https://github.com/microsoft/TypeScript/tree/main/lib).

--- a/docs/tsconfig/ja/options/lib.md
+++ b/docs/tsconfig/ja/options/lib.md
@@ -66,4 +66,4 @@ TypeScriptには組み込みのJS API（例：`Math`）の型定義や、ブラ�
 | `ESNext.Intl`             |
 | `ESNext.Symbol`           |
 
-もしこのリストが古くなっている場合は、完全なリストを[TypeScript source code](https://github.com/microsoft/TypeScript/tree/master/lib)で読むことができます。
+もしこのリストが古くなっている場合は、完全なリストを[TypeScript source code](https://github.com/microsoft/TypeScript/tree/main/lib)で読むことができます。

--- a/docs/tsconfig/ko/options/lib.md
+++ b/docs/tsconfig/ko/options/lib.md
@@ -66,4 +66,4 @@ TypeScript는 JS API(`Math` 와 같은)에 대한 기본적인 타입 정의와 
 | `ESNext.Intl`             |
 | `ESNext.Symbol`           |
 
-위 목록들은 최신이 아닐수도 있습니다. 전체적인 목록은 [TypeScript의 소스 코드](https://github.com/microsoft/TypeScript/tree/master/lib) 에서 조회할 수 있습니다.
+위 목록들은 최신이 아닐수도 있습니다. 전체적인 목록은 [TypeScript의 소스 코드](https://github.com/microsoft/TypeScript/tree/main/lib) 에서 조회할 수 있습니다.

--- a/docs/tsconfig/pt/options/lib.md
+++ b/docs/tsconfig/pt/options/lib.md
@@ -66,4 +66,4 @@ Você pode querer alterá-los por alguns motivos:
 | `ESNext.Intl`             |
 | `ESNext.Symbol`           |
 
-Esta lista pode estar desatualizada, você pode ver a lista completa no [TypeScript source code](https://github.com/microsoft/TypeScript/tree/master/lib).
+Esta lista pode estar desatualizada, você pode ver a lista completa no [TypeScript source code](https://github.com/microsoft/TypeScript/tree/main/lib).

--- a/docs/tsconfig/zh/options/lib.md
+++ b/docs/tsconfig/zh/options/lib.md
@@ -66,4 +66,4 @@ TypeScript 还包括与你指定的 `target` 选项相匹配的较新的 JS 特�
 | `ESNext.Intl`             |
 | `ESNext.Symbol`           |
 
-此列表有可能会过期，你可以在 [TypeScript 源码中](https://github.com/microsoft/TypeScript/tree/master/lib)查看完整列表。
+此列表有可能会过期，你可以在 [TypeScript 源码中](https://github.com/microsoft/TypeScript/tree/main/src/lib)查看完整列表。


### PR DESCRIPTION
I find TypeScript repo main branch changed 'master' to 'main'. but the links in the translation didn't change